### PR TITLE
jQuery chaining

### DIFF
--- a/touche.js
+++ b/touche.js
@@ -54,6 +54,7 @@
       var event = arguments[0];
       arguments[0] = event === 'click' ? 'touchend' : event;
       originalOnMethod.apply(this, arguments);
+      return this;
     };
   }
 })();


### PR DESCRIPTION
in jquery you always need to return the original object in order to allow chaining, such as:
$(element).on("click", function() {}).on("mouseover", function() {});
