### PR TITLE
Capture namespaced events

### DIFF
--- a/src/touche.js
+++ b/src/touche.js
@@ -64,7 +64,10 @@
     // Change event type and re-apply .on() method
     jQuery.fn.on = function() {
       var event = arguments[0];
-      arguments[0] = event === 'click' ? 'touchend' : event;
+      
+      if( event.slice(0, 4) == 'click' )
+        arguments[0] = event.replace('click', 'touchend');
+        
       originalOnMethod.apply(this, arguments);
       return this;
     };


### PR DESCRIPTION
Things like Bootstrap use namespaced events, e.g. `"click.modal.data-api"` which don't match `event === 'click'`.
