### PR TITLE
Fixes on jQuery related portion of the code

### DIFF
--- a/src/touche.js
+++ b/src/touche.js
@@ -59,16 +59,31 @@
 
   // Has the developer used jQuery?
   if (window.jQuery && isTouch) {
-    var originalOnMethod = jQuery.fn.on;
+    var originalOnMethod  = jQuery.fn.on,
+        originalOffMethod = jQuery.fn.off;
+
+    var replaceEventName = function (event) {
+      if (event.slice(0, 5) == 'click') {
+        return event.replace('click', 'touchend');
+      }
+      return event;
+    }
 
     // Change event type and re-apply .on() method
     jQuery.fn.on = function() {
-      var event = arguments[0];
-      
-      if( event.slice(0, 5) == 'click' )
-        arguments[0] = event.replace('click', 'touchend');
+      // arguments[0] is the event name
+      arguments[0] = replaceEventName(arguments[0]);
         
       originalOnMethod.apply(this, arguments);
+      return this;
+    };
+
+    // Change event type and re-apply .off() method
+    jQuery.fn.off = function() {
+      // arguments[0] is the event name
+      arguments[0] = replaceEventName(arguments[0]);
+        
+      originalOffMethod.apply(this, arguments);
       return this;
     };
   }


### PR DESCRIPTION
Hi!

I've started using this library yesterday (thanks for it!), but soon realised that the jQuery support is broken.

First of all, click events are never converted to touchend events, as this line is wrong

```
if( event.slice(0, 4) == 'click' )
```

(event.slice(0, 4) returns 'clic')

It's definitely a critical bug, and it's fixed in the first commit.

Second bug is around jQuery.off(): you can on() a click event, and that's converted into a touchend event, but if you try to off() it won't work. Fixed in the second commit.

Let me know if you need more info! 

Cheers,
Davide.
