### PR TITLE
Support jQuery 1.10.0 or higher

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
   "main": "src/touche.js",
   "license": "MIT",
   "dependencies": {
-    "jquery": "~1.10.0"
+    "jquery": ">=1.10.0"
   },
   "_resolution": {
     "type": "branch",


### PR DESCRIPTION
We're way past jQuery v1.10.0 here and touche seems to work fine with the new jquery.